### PR TITLE
Introduce CI for Pull Request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,14 @@
-name: deploy
+name: CI
 
 on:
   push:
     branches: [feedforce]
+  pull_request:
   schedule:
     - cron: '0 1 * * *' # at 10:00am everyday (JST)
 
 jobs:
-  deploy:
+  build_and_deploy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -25,6 +26,7 @@ jobs:
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
+        if: ${{ github.ref == 'refs/heads/feedforce' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./out

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Feedforce Engineers' Blogs
 
+![CI workflow status](https://github.com/feedforce/team-blog-hub/actions/workflows/ci.yml/badge.svg)
+
 https://feedforce.github.io/team-blog-hub
 
 フィードフォースグループに所属するエンジニアのブログ記事をまとめています。


### PR DESCRIPTION
## Why?

セルフマージしやすいように、コードが壊れていないかを PR 内で確認できた方が精神的に良い。

GitHub Actions で実行している処理のうち、GitHub Pages へのデプロイ部分以外は Pull Request 作成時にも実行するようにしてみた。

## How?

* GitHub Actions に以下の変更をした
  * PR 作成時にもトリガーされるようにした
  * GitHub Pages へのデプロイは `feedforce` ブランチでのみ実行されるようにした
  * ファイル名やジョブ名などを変更
* Branch protection rule の設定で CI が通っていることを条件に追加

  <img width="936" alt="image" src="https://user-images.githubusercontent.com/10208211/131628168-23e5f11a-9499-4cc3-970b-5b538de47db8.png">

* README に [GitHub Actions のバッジ](https://docs.github.com/ja/actions/managing-workflow-runs/adding-a-workflow-status-badge)を追加