### PR TITLE
60 日間アクティビティがないと Scheduled workflow が止まってしまうことへの対策

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,7 @@ jobs:
           user_email: 'github-actions[bot]@users.noreply.github.com'
           publish_dir: ./out
           cname: engineers.feedforce.jp
+
+      # 60 日間アクティビティがないと Scheduled workflow が止まってしまうことへの対策
+      # See: https://docs.github.com/ja/actions/managing-workflow-runs/disabling-and-enabling-a-workflow
+      - uses: gautamkrishnar/keepalive-workflow@master


### PR DESCRIPTION
## Why?

GitHub Actions の Scheduled workflow は 60 日間アクティビティがないリポジトリではトリガーされなくなってしまう仕様だった。

> Warning: To prevent unnecessary workflow runs, scheduled workflows may be disabled automatically. When a public repository is forked, scheduled workflows are disabled by default. In a public repository, scheduled workflows are automatically disabled when no repository activity has occurred in 60 days.
>
> https://docs.github.com/en/actions/managing-workflow-runs/disabling-and-enabling-a-workflow

とはいえ、他の CI ツールを使うのは管理しづらくなってしまうため、できれば GitHub Actions を使いたい。

## How?

アクティビティの定義については書かれていなかったが、どうやらメインブランチへのコミットが必要そうで、`gh-pages` ブランチは 28 日前にコミットがあったのに Scheduled workflow が止まっていた。

また `feedforce` ブランチの最終コミットは 10/1 で、GitHub Actions が止まってしまったのは 12/2 からだったため、メインブランチへのコミットが必要と思われる。

メインブランチにコミットするとなると、手軽そうなのは Dependabot を使うことだが、このリポジトリは fork している関係で、依存パッケージをアップデートしていくと本体の変更を取り込む際にコンフリクトの解消が面倒になる恐れがある。

そのため、空コミットを入れる方法にした。

調べたところ、以下のリポジトリで提供されている action を使うのが一番簡単そうであった。

[gautamkrishnar/keepalive-workflow: GitHub action to prevent GitHub from suspending your cronjob based triggers due to repository inactivity](https://github.com/gautamkrishnar/keepalive-workflow)

メインブランチに空コミットが増えてしまうのは鬱陶しいものの、この action はデフォルト設定では 50 日間コミットがなかった場合のみ空コミットを入れてくれるので、空コミットがノイズになるほどではなさそう。