### PR TITLE
Update masutaka avatar

### DIFF
--- a/members.ts
+++ b/members.ts
@@ -42,7 +42,7 @@ export const members: Member[] = [
     name: "masutaka",
     role: "LookML Developer",
     bio: "カレー大好き！",
-    avatarSrc: "https://www.gravatar.com/avatar/b7a93b5c3bcfa8f2f8047584cc16bf13?size=256",
+    avatarSrc: "https://www.gravatar.com/avatar/d6c5403c0b6ef2f9fd51910ea38323a3?size=256",
     sources: [
       "https://developer.feedforce.jp/rss/author/masutaka26",
       "https://masutaka.net/chalow/cl.rss",


### PR DESCRIPTION
ここで作ってくれたイラストを @katsunn が単体の画像ファイルに切り出してくれた。
[「謙虚な人が多い」「有休みたいに育休がとれる」エンジニアが語る、フィードフォースのぶっちゃけ裏話｜フィードフォースのnote](https://media.feedforce.jp/n/n98075add5154)

https://ja.gravatar.com/site/implement/images/ の [Creating the Hash](https://ja.gravatar.com/site/implement/hash/) を参考にした。

```
$ printf 'masutaka.net@gmail.com' | md5
d6c5403c0b6ef2f9fd51910ea38323a3
```

というか、今までのハッシュ値はなんだったんや...？ gravatar のデフォルトの画像には変わりはないのだが...。